### PR TITLE
Update automation schedule to run every 4 hours for economical reason.

### DIFF
--- a/.github/workflows/all-regions.yml
+++ b/.github/workflows/all-regions.yml
@@ -2,7 +2,7 @@ name: All Regions Network Benchmark
 
 on:
   schedule:
-    - cron: '0 */3 * * *'  # Runs every 3 hours
+    - cron: '0 */4 * * *'  # Runs every 4 hours
   workflow_dispatch:  # Allow manual trigger
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The Azure Storage Account used for storing test results is secured with the foll
 - **Test VMs**: Automatic deployment of Linux virtual machines across 3 availability zones
 - **Network Testing**: Uses `qperf` to measure TCP latency and bandwidth (`iperf3` is deployed but not used for the moment)
 - **Data Storage**: Azure Table Storage for results persistence
-- **Automation**: GitHub Actions for test execution every 3 hours
+- **Automation**: GitHub Actions for test execution every 4 hours
 
 ### Visualization Dashboard
 - **Frontend**: Static web application with interactive visualizations
@@ -203,7 +203,7 @@ benchmark = {
 ```yaml
 # In .github/workflows/all-regions.yml
 schedule:
-  - cron: '0 */3 * * *'  # Every 3 hours
+  - cron: '0 */4 * * *'  # Every 4 hours
 ```
 
 ### Monitoring and Logs


### PR DESCRIPTION
This pull request updates the automation schedule for the network benchmark workflow to run less frequently. The schedule is changed from every 3 hours to every 4 hours, and the related documentation is updated to match.

Automation schedule update:

* [`.github/workflows/all-regions.yml`](diffhunk://#diff-4a335ba3a7643ef33b278c3b11b474eea03f74ab9824e46e9305f52cf61a8e20L5-R5): Changed the workflow schedule from every 3 hours to every 4 hours.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L39-R39): Updated all references to the automation schedule from every 3 hours to every 4 hours, including in the feature list and example YAML. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L39-R39) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L206-R206)